### PR TITLE
Allow condition matching when given a class

### DIFF
--- a/lib/access-granted/permission.rb
+++ b/lib/access-granted/permission.rb
@@ -20,7 +20,7 @@ module AccessGranted
     end
 
     def matches_conditions?(subject)
-      if @block && !subject.is_a?(Class)
+      if @block
         @block.call(subject, @user)
       else
         matches_hash_conditions?(subject)

--- a/spec/permission_spec.rb
+++ b/spec/permission_spec.rb
@@ -14,12 +14,6 @@ describe AccessGranted::Permission do
       perm = subject.new(true, :read, sub.class, nil, {}, proc {|el| el.published? })
       expect(perm.matches_conditions?(sub)).to eq(true)
     end
-
-    it "does not match proc conditions when given a class instead of an instance" do
-      sub = double("Element", published?: true)
-      perm = subject.new(true, :read, sub.class, nil, {}, proc {|el| el.published? })
-      expect(perm.matches_conditions?(sub.class)).to eq(true)
-    end
   end
 
   describe "#matches_hash_conditions?" do

--- a/spec/policy_spec.rb
+++ b/spec/policy_spec.rb
@@ -68,7 +68,7 @@ describe AccessGranted::Policy do
         klass = Class.new do
           include AccessGranted::Policy
 
-          def configure(user)
+          def configure
             role :member do
               can :manage, FakePost
             end


### PR DESCRIPTION
We have a couple of use cases where we compare a given action against a class i.e
```
can?(:see, Project)
```

This functionality was removed [here](https://github.com/chaps-io/access-granted/pull/16). The way we structure/check permissions already accounts for the premise of that PR.